### PR TITLE
Add documentation links to user interfaces.

### DIFF
--- a/trait2d_analysis_gui/dialog_import.ui
+++ b/trait2d_analysis_gui/dialog_import.ui
@@ -260,6 +260,22 @@
     <string>Data options</string>
    </property>
   </widget>
+  <widget class="QLabel" name="labelDocumentation">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>230</y>
+     <width>521</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>&lt;b&gt;&lt;a href=&quot;https://eggeling-lab-microscope-software.github.io/TRAIT2D/analysis_gui.html#data-import-dialog&quot;&gt;Documentation&lt;/a&gt;&lt;/b&gt;</string>
+   </property>
+   <property name="openExternalLinks">
+    <bool>true</bool>
+   </property>
+  </widget>
   <zorder>groupBox_2</zorder>
   <zorder>groupBox</zorder>
   <zorder>buttonBox</zorder>
@@ -275,6 +291,7 @@
   <zorder>label_6</zorder>
   <zorder>label_7</zorder>
   <zorder>comboBoxColId</zorder>
+  <zorder>labelDocumentation</zorder>
  </widget>
  <resources/>
  <connections>

--- a/trait2d_analysis_gui/tab/adc.ui
+++ b/trait2d_analysis_gui/tab/adc.ui
@@ -769,6 +769,22 @@
     <string>Max. fit iterations</string>
    </property>
   </widget>
+  <widget class="QLabel" name="labelDocumentation">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>860</y>
+     <width>371</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>&lt;b&gt;&lt;a href=&quot;https://eggeling-lab-microscope-software.github.io/TRAIT2D/analysis_gui.html#adc-analysis-tab&quot;&gt;Documentation&lt;/a&gt;&lt;/b&gt;</string>
+   </property>
+   <property name="openExternalLinks">
+    <bool>true</bool>
+   </property>
+  </widget>
  </widget>
  <customwidgets>
   <customwidget>

--- a/trait2d_analysis_gui/tab/msd.ui
+++ b/trait2d_analysis_gui/tab/msd.ui
@@ -526,6 +526,22 @@
     </property>
    </widget>
   </widget>
+  <widget class="QLabel" name="labelDocumentation">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>770</y>
+     <width>371</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>&lt;b&gt;&lt;a href=&quot;https://eggeling-lab-microscope-software.github.io/TRAIT2D/analysis_gui.html#msd-analysis-tab&quot;&gt;Documentation&lt;/a&gt;&lt;/b&gt;</string>
+   </property>
+   <property name="openExternalLinks">
+    <bool>true</bool>
+   </property>
+  </widget>
  </widget>
  <customwidgets>
   <customwidget>

--- a/trait2d_simulator_gui/__init__.py
+++ b/trait2d_simulator_gui/__init__.py
@@ -15,6 +15,8 @@ import numpy as np
 import tkinter as tk
 from tkinter import filedialog
 from tkinter import ttk
+from tkinter import font
+import webbrowser
 
 # for plotting
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
@@ -295,6 +297,14 @@ class MainVisual(tk.Frame):
         self.button2 = tk.Button(text="    SAVE   ", command=self.save_images,
                                  width=int(self.button_size/4), bg='gray')
         self.button2.grid(row=33, column=3, columnspan=6, pady=10, padx=30)
+
+        # Link to GUI documentation.
+        label_font = font.nametofont(ttk.Style().lookup("TLabel", "font"))
+        link_font = font.Font(**label_font.configure())
+        link_font.configure(underline=1, weight='bold')
+        lblDocs = tk.Label(master=root, text="Documentation", font=link_font, fg='blue', bg='gray')
+        lblDocs.grid(row=34, column=1, columnspan=1, pady=5)
+        lblDocs.bind("<Button-1>", lambda e: webbrowser.open_new("https://eggeling-lab-microscope-software.github.io/TRAIT2D/simulator_gui.html#description-of-the-gui"))
 
     def generate_trajectory(self):
         '''

--- a/trait2d_tracker_gui/__init__.py
+++ b/trait2d_tracker_gui/__init__.py
@@ -21,7 +21,9 @@ import numpy as np
 import cv2
 import tkinter as tk
 from tkinter import filedialog
+from tkinter import font, ttk
 import csv
+import webbrowser
 
 # for plotting
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
@@ -215,6 +217,13 @@ class MainVisual(tk.Frame):
         self.scale_movie.set(self.frame_pos)        
         self.scale_movie.grid(row=21, column=1, columnspan=3, pady=5, padx=5) 
         
+        # Link to GUI documentation.
+        label_font = font.nametofont(ttk.Style().lookup("TLabel", "font"))
+        link_font = font.Font(**label_font.configure())
+        link_font.configure(underline=1, weight='bold')
+        lblDocs = tk.Label(master=root, text="Documentation", font=link_font, fg='blue', bg='white')
+        lblDocs.grid(row=22, column=1, columnspan=1, pady=5)
+        lblDocs.bind("<Button-1>", lambda e: webbrowser.open_new("https://eggeling-lab-microscope-software.github.io/TRAIT2D/tracker_gui.html#description-of-the-gui"))
 
 
     def show_frame(self , centers=[]):


### PR DESCRIPTION
This adds documentation links to all GUI pages. (Will always point to the documentation of the latest commit.)

See the image below for an example:

![image](https://user-images.githubusercontent.com/57045940/139138426-79bbb9b1-1b04-4c09-b1ed-91885bf55b48.png)
