### PR TITLE
Pin docutils requirement to fix doc build errors.

### DIFF
--- a/sphinx/requirements.txt
+++ b/sphinx/requirements.txt
@@ -1,4 +1,5 @@
 # sphinx/requirements.txt
+docutils==0.12
 sphinx==3.2.1
 sphinx-gallery==0.8.1
 sphinx_rtd_theme==0.5.0


### PR DESCRIPTION
This pins the `docutils` requirement to version `0.12` as the latest version throws errors when building the documentation.