### PR TITLE
Add CITATION.cff with Zenodo concept DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,22 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Reina"
+  given-names: "Francesco"
+  orcid: "https://orcid.org/0000-0001-6752-9089"
+- family-names: "Wigg"
+  given-names: "John Maxwell Andreas"
+- family-names: "Dmitrieva"
+  given-names: "Mariia"
+- family-names: "Lefebvre"
+  given-names: "Joёl"
+- family-names: "Rittscher"
+  given-names: "Jens"
+- family-names: "Eggeling"
+  given-names: "Christian"
+- family-names: "Vogler"
+  given-names: "Bela"
+title: "TRAIT2D: a Software for Quantitative Analysis of Single Particle Diffusion Data"
+doi: 10.5281/zenodo.4725268
+date-released: 2021-06-21
+url: "https://github.com/Eggeling-Lab-Microscope-Software/TRAIT2D"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,14 +8,14 @@ authors:
   given-names: "John Maxwell Andreas"
 - family-names: "Dmitrieva"
   given-names: "Mariia"
+- family-names: "Vogler"
+  given-names: "Bela"
 - family-names: "Lefebvre"
   given-names: "Joёl"
 - family-names: "Rittscher"
   given-names: "Jens"
 - family-names: "Eggeling"
   given-names: "Christian"
-- family-names: "Vogler"
-  given-names: "Bela"
 title: "TRAIT2D: a Software for Quantitative Analysis of Single Particle Diffusion Data"
 doi: 10.5281/zenodo.4725268
 date-released: 2021-06-21


### PR DESCRIPTION
When working on my master's thesis I found out about the `CITATION.cff` file which is a neat way to make a code repository citable. 

GitHub actually adds a cool button so you can directly export a BibTex citation without having to navigate to Zenodo first:

![image](https://user-images.githubusercontent.com/57045940/139685111-bef23b8b-8362-4625-a693-cec99bb2786f.png)

I used Zenodo's concept DOI which always resolved to the latest version so we don't have to update it manually. You can still head over to Zenodo to cite a specific version or just do it manually.

I added everyone who is listed as an author of the paper as an author as well as @Zatyrus.

Let me know if you'd like anything changed, otherwise I will merge this next week or so.