### PR TITLE
Fix analysis GUI warnings and Simulator GUI error.

### DIFF
--- a/trait2d_analysis_gui/tab/adc.py
+++ b/trait2d_analysis_gui/tab/adc.py
@@ -81,7 +81,7 @@ class widgetADC(QWidget):
             mb.exec()
             return
 
-        T = self.parent.track.get_t()[0:-3]
+        T = self.parent.track.get_t()[1:-2]
         fit_max_time = self.plot.get_range()
         if fit_max_time <= 0.0:
             fit_max_time = None

--- a/trait2d_simulator_gui/__init__.py
+++ b/trait2d_simulator_gui/__init__.py
@@ -167,7 +167,10 @@ class MainVisual(tk.Frame):
         lbl6 = tk.Label(master=root, text=" Random generator seed [seed, integer]",
                         width=self.button_size, bg='gray', compound=tk.LEFT)
         lbl6.grid(row=11, column=1, columnspan=2)
-        v = tk.StringVar(root, value=str(self.seed))
+        if (self.seed == None):
+            v = tk.StringVar(root, value='')
+        else:
+            v = tk.StringVar(root, value=str(self.seed))
         self.param_seed = tk.Entry(root, width=int(self.button_size/4), text=v)
         self.param_seed.grid(row=11, column=3, columnspan=6)
 


### PR DESCRIPTION
Fixes the warnings emitted by the ADC analysis tab of the analysis GUI. Closes #51.

Also fixes the error when using the default values in the simulator GUI (was caused by the default value for the seed being `None` which couldn't be converted back to an integer). So I think this closes #50 as well.